### PR TITLE
feat: add geo capabilities

### DIFF
--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/NGSIToPostgreSQL.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/NGSIToPostgreSQL.java
@@ -292,7 +292,7 @@ public class NGSIToPostgreSQL extends AbstractSessionFactoryProcessor {
 
                     ResultSet columnDataType = conn.createStatement().executeQuery(postgres.getColumnsTypesQuery(tableName));
                     Map<String, POSTGRESQL_COLUMN_TYPES> updatedListOfTypedFields;
-                    if(columnDataType !=null)
+                    if(columnDataType != null)
                         updatedListOfTypedFields = postgres.getUpdatedListOfTypedFields(columnDataType, listOfFields);
                     else updatedListOfTypedFields = listOfFields;
 

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/NGSIToPostgreSQL.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/NGSIToPostgreSQL.java
@@ -292,7 +292,7 @@ public class NGSIToPostgreSQL extends AbstractSessionFactoryProcessor {
 
                     ResultSet columnDataType = conn.createStatement().executeQuery(postgres.getColumnsTypesQuery(tableName));
                     Map<String, POSTGRESQL_COLUMN_TYPES> updatedListOfTypedFields;
-                    if(columnDataType != null)
+                    if(columnDataType !=null)
                         updatedListOfTypedFields = postgres.getUpdatedListOfTypedFields(columnDataType, listOfFields);
                     else updatedListOfTypedFields = listOfFields;
 

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/backends/PostgreSQLBackend.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/backends/PostgreSQLBackend.java
@@ -72,7 +72,7 @@ public class PostgreSQLBackend {
                         aggregation.putIfAbsent(encodedGeopropertyLon, POSTGRESQL_COLUMN_TYPES.NUMERIC);
                         aggregation.putIfAbsent(encodedGeopropertyLat, POSTGRESQL_COLUMN_TYPES.NUMERIC);
                     }
-                    String encodedGeoJson = encodeAttributeToColumnName(attribute.getAttrName(), "geometry", datasetIdPrefixToTruncate);
+                    String encodedGeoJson = encodeAttributeToColumnName(attribute.getAttrName(), "geojson", datasetIdPrefixToTruncate);
                     String encodedFeatureGeoProperties = encodeAttributeToColumnName(attribute.getAttrName(), "feature", datasetIdPrefixToTruncate);
                     aggregation.putIfAbsent(encodedGeoJson, POSTGRESQL_COLUMN_TYPES.GEOMETRY);
                     aggregation.putIfAbsent(encodedFeatureGeoProperties, POSTGRESQL_COLUMN_TYPES.TEXT);
@@ -258,7 +258,7 @@ public class PostgreSQLBackend {
             JSONObject featureObject = new JSONObject();
             featureObject.put("type", "Feature");
             featureObject.put("geometry", geometryObject);
-            String encodedGeoJson = encodeAttributeToColumnName(attribute.getAttrName(), "geometry", datasetIdPrefixToTruncate);
+            String encodedGeoJson = encodeAttributeToColumnName(attribute.getAttrName(), "geojson", datasetIdPrefixToTruncate);
             String encodedFeatureGeoProperties = encodeAttributeToColumnName(attribute.getAttrName(), "feature", datasetIdPrefixToTruncate);
             valuesForColumns.put(encodedGeoJson, formatFieldForValueInsert(geometryObject.getJSONObject("value"), listOfFields.get(encodedGeoJson)));
             valuesForColumns.put(encodedFeatureGeoProperties, formatFieldForValueInsert(featureObject, listOfFields.get(encodedFeatureGeoProperties)));

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/backends/PostgreSQLBackend.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/backends/PostgreSQLBackend.java
@@ -72,11 +72,12 @@ public class PostgreSQLBackend {
                         aggregation.putIfAbsent(encodedGeopropertyLon, POSTGRESQL_COLUMN_TYPES.NUMERIC);
                         aggregation.putIfAbsent(encodedGeopropertyLat, POSTGRESQL_COLUMN_TYPES.NUMERIC);
                     }
+                    String encodedGeometry = encodeAttributeToColumnName(attribute.getAttrName(), "geometry", datasetIdPrefixToTruncate);
                     String encodedGeoJson = encodeAttributeToColumnName(attribute.getAttrName(), "geojson", datasetIdPrefixToTruncate);
-                    String encodedFeatureGeoProperties = encodeAttributeToColumnName(attribute.getAttrName(), "feature", datasetIdPrefixToTruncate);
-                    aggregation.putIfAbsent(encodedGeoJson, POSTGRESQL_COLUMN_TYPES.GEOMETRY);
-                    aggregation.putIfAbsent(encodedFeatureGeoProperties, POSTGRESQL_COLUMN_TYPES.TEXT);
-                    aggregation.putIfAbsent(attrName, POSTGRESQL_COLUMN_TYPES.TEXT);
+                    String encodedLocation = attrName;
+                    aggregation.putIfAbsent(encodedGeometry, POSTGRESQL_COLUMN_TYPES.GEOMETRY);
+                    aggregation.putIfAbsent(encodedGeoJson, POSTGRESQL_COLUMN_TYPES.TEXT);
+                    aggregation.putIfAbsent(encodedLocation, POSTGRESQL_COLUMN_TYPES.TEXT);
                 } else aggregation.putIfAbsent(attrName, POSTGRESQL_COLUMN_TYPES.TEXT);
                 logger.debug("Added {} in the list of fields for entity {}", attrName, entity.entityId);
 
@@ -255,14 +256,17 @@ public class PostgreSQLBackend {
                 valuesForColumns.put(encodedGeopropertyLon, formatFieldForValueInsert(location.getDouble(0), listOfFields.get(encodedGeopropertyLon)));
                 valuesForColumns.put(encodedGeopropertyLat, formatFieldForValueInsert(location.getDouble(1), listOfFields.get(encodedGeopropertyLat)));
             }
-            JSONObject featureObject = new JSONObject();
-            featureObject.put("type", "Feature");
-            featureObject.put("geometry", geometryObject);
+            JSONObject geoJson = new JSONObject();
+            geoJson.put("type", "Feature");
+            geoJson.put("geometry", geometryObject);
+
+            String encodedGeometry = encodeAttributeToColumnName(attribute.getAttrName(), "geometry", datasetIdPrefixToTruncate);
             String encodedGeoJson = encodeAttributeToColumnName(attribute.getAttrName(), "geojson", datasetIdPrefixToTruncate);
-            String encodedFeatureGeoProperties = encodeAttributeToColumnName(attribute.getAttrName(), "feature", datasetIdPrefixToTruncate);
-            valuesForColumns.put(encodedGeoJson, formatFieldForValueInsert(geometryObject.getJSONObject("value"), listOfFields.get(encodedGeoJson)));
-            valuesForColumns.put(encodedFeatureGeoProperties, formatFieldForValueInsert(featureObject, listOfFields.get(encodedFeatureGeoProperties)));
-            valuesForColumns.put(encodedAttributeName, formatFieldForValueInsert(location, listOfFields.get(encodedAttributeName)));
+            String encodedLocation = encodedAttributeName;
+
+            valuesForColumns.put(encodedGeometry, formatFieldForValueInsert(geometryObject.getJSONObject("value"), listOfFields.get(encodedGeometry)));
+            valuesForColumns.put(encodedGeoJson, formatFieldForValueInsert(geoJson, listOfFields.get(encodedGeoJson)));
+            valuesForColumns.put(encodedLocation, formatFieldForValueInsert(location, listOfFields.get(encodedLocation)));
         }
         else {
             valuesForColumns.put(encodedAttributeName, formatFieldForValueInsert(attribute.getAttrValue(), listOfFields.get(encodedAttributeName)));

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIConstants.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIConstants.java
@@ -63,7 +63,8 @@ public final class NGSIConstants {
     public static enum POSTGRESQL_COLUMN_TYPES {
         TEXT,
         TIMESTAMPTZ,
-        NUMERIC
+        NUMERIC,
+        GEOMETRY
     }
 
     public static final String OBSERVED_AT = "observedAt";

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIUtils.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIUtils.java
@@ -150,7 +150,7 @@ public class NGSIUtils {
         } else if ("Property".contentEquals(attrType)) {
             attrValue = value.get("value");
         } else if ("GeoProperty".contentEquals(attrType)) {
-            attrValue = value.getJSONObject("value").get("coordinates").toString();
+            attrValue = value.getJSONObject("value").getString("type");
         } else if("".contentEquals(attrType)){
             attrType = null;
             attrValue = null;
@@ -166,7 +166,14 @@ public class NGSIUtils {
                 if (value.get(keyOne) instanceof String)
                     subAttributes.add(new AttributesLD(keyOne.toLowerCase(), "Property", "", "", "", "", value.getString(keyOne), false, null));
                 else subAttributes.add(new AttributesLD(keyOne.toLowerCase(), "Property", "", "", "", "", null, false, null));
-
+            } else if ("GeoProperty".equals(attrType) && "value".equals(keyOne)) {
+                if(attrValue.equals("Point")) {
+                    String [] location = value.getJSONObject("value").get("coordinates").toString().replaceAll("\\[", "").replaceAll("\\]", "").split(",");
+                    subAttributes.add(new AttributesLD("lon", "GeoProperty", "", "", "", "", Double.parseDouble(location[0]), false, null));
+                    subAttributes.add(new AttributesLD("lat", "GeoProperty", "", "", "", "", Double.parseDouble(location[1]), false, null));
+                } else {
+                    subAttributes.add(new AttributesLD("geometry", "GeoProperty", "", "", "", "", value.getJSONObject("value"), false, null));
+                }
             } else if ("RelationshipDetails".contains(keyOne)) {
                 JSONObject relation = value.getJSONObject(keyOne);
                 relation.remove("id");

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIUtils.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIUtils.java
@@ -150,7 +150,12 @@ public class NGSIUtils {
         } else if ("Property".contentEquals(attrType)) {
             attrValue = value.get("value");
         } else if ("GeoProperty".contentEquals(attrType)) {
-            attrValue = value.getJSONObject("value").getString("type");
+            if(value.getJSONObject("value").getString("type").equals("Point")){
+                attrValue = value.getJSONObject("value").get("coordinates");
+            } else {
+                attrValue = value.getJSONObject("value");
+
+            }
         } else if("".contentEquals(attrType)){
             attrType = null;
             attrValue = null;
@@ -166,14 +171,6 @@ public class NGSIUtils {
                 if (value.get(keyOne) instanceof String)
                     subAttributes.add(new AttributesLD(keyOne.toLowerCase(), "Property", "", "", "", "", value.getString(keyOne), false, null));
                 else subAttributes.add(new AttributesLD(keyOne.toLowerCase(), "Property", "", "", "", "", null, false, null));
-            } else if ("GeoProperty".equals(attrType) && "value".equals(keyOne)) {
-                if(attrValue.equals("Point")) {
-                    String [] location = value.getJSONObject("value").get("coordinates").toString().replaceAll("\\[", "").replaceAll("\\]", "").split(",");
-                    subAttributes.add(new AttributesLD("lon", "GeoProperty", "", "", "", "", Double.parseDouble(location[0]), false, null));
-                    subAttributes.add(new AttributesLD("lat", "GeoProperty", "", "", "", "", Double.parseDouble(location[1]), false, null));
-                } else {
-                    subAttributes.add(new AttributesLD("geometry", "GeoProperty", "", "", "", "", value.getJSONObject("value"), false, null));
-                }
             } else if ("RelationshipDetails".contains(keyOne)) {
                 JSONObject relation = value.getJSONObject(keyOne);
                 relation.remove("id");

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIUtils.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIUtils.java
@@ -150,12 +150,7 @@ public class NGSIUtils {
         } else if ("Property".contentEquals(attrType)) {
             attrValue = value.get("value");
         } else if ("GeoProperty".contentEquals(attrType)) {
-            if(value.getJSONObject("value").getString("type").equals("Point")){
-                attrValue = value.getJSONObject("value").get("coordinates");
-            } else {
-                attrValue = value.getJSONObject("value");
-
-            }
+            attrValue = value;
         } else if("".contentEquals(attrType)){
             attrType = null;
             attrValue = null;

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIUtils.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/utils/NGSIUtils.java
@@ -166,6 +166,7 @@ public class NGSIUtils {
                 if (value.get(keyOne) instanceof String)
                     subAttributes.add(new AttributesLD(keyOne.toLowerCase(), "Property", "", "", "", "", value.getString(keyOne), false, null));
                 else subAttributes.add(new AttributesLD(keyOne.toLowerCase(), "Property", "", "", "", "", null, false, null));
+
             } else if ("RelationshipDetails".contains(keyOne)) {
                 JSONObject relation = value.getJSONObject(keyOne);
                 relation.remove("id");

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/test/java/org/apache/nifi/processors/ngsi/TestNGSIToPostgreSQL.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/test/java/org/apache/nifi/processors/ngsi/TestNGSIToPostgreSQL.java
@@ -765,7 +765,7 @@ runner.setProperty(NGSIToMySQL.ENABLE_ENCODING, "true");
 
         long creationTime = 1562561734983l;
 
-        String expectedValuesForInsert = "('urn:ngsi-ld:NifiTest:Test01','NifiTest',$$urn:ngsi-ld:RelationTest:Test03$$,$$ES$$,'2020-09-29T09:00:00Z',null,$$urn:ngsi-ld:RelationTest:Test02$$,$$USA$$,'2020-09-29T09:00:00Z',null,$$[3.63969,43.43358]$$,'2020-09-29T09:00:00Z',null,$$test 01$$,'2020-09-29T09:00:00Z',null,'2019-07-08T04:55:34.983Z',null,'2020-09-29T09:00:00Z',null)";
+        String expectedValuesForInsert = "('urn:ngsi-ld:NifiTest:Test01','NifiTest',$$urn:ngsi-ld:RelationTest:Test03$$,$$ES$$,'2020-09-29T09:00:00Z',null,$$urn:ngsi-ld:RelationTest:Test02$$,$$USA$$,'2020-09-29T09:00:00Z',null,$$Point$$,'2020-09-29T09:00:00Z',43.43358,3.63969,null,$$test 01$$,'2020-09-29T09:00:00Z',null,'2019-07-08T04:55:34.983Z',null,'2020-09-29T09:00:00Z',null)";
         List<String> valuesForInsert = backend.getValuesForInsert(
                 attrPersistence,
                 entities.get(0),

--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/test/java/org/apache/nifi/processors/ngsi/TestNGSIToPostgreSQL.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/test/java/org/apache/nifi/processors/ngsi/TestNGSIToPostgreSQL.java
@@ -765,7 +765,7 @@ runner.setProperty(NGSIToMySQL.ENABLE_ENCODING, "true");
 
         long creationTime = 1562561734983l;
 
-        String expectedValuesForInsert = "('urn:ngsi-ld:NifiTest:Test01','NifiTest',$$urn:ngsi-ld:RelationTest:Test03$$,$$ES$$,'2020-09-29T09:00:00Z',null,$$urn:ngsi-ld:RelationTest:Test02$$,$$USA$$,'2020-09-29T09:00:00Z',null,$$Point$$,'2020-09-29T09:00:00Z',43.43358,3.63969,null,$$test 01$$,'2020-09-29T09:00:00Z',null,'2019-07-08T04:55:34.983Z',null,'2020-09-29T09:00:00Z',null)";
+        String expectedValuesForInsert = "('urn:ngsi-ld:NifiTest:Test01','NifiTest',$$urn:ngsi-ld:RelationTest:Test03$$,$$ES$$,'2020-09-29T09:00:00Z',null,$$urn:ngsi-ld:RelationTest:Test02$$,$$USA$$,'2020-09-29T09:00:00Z',null,$$[3.63969,43.43358]$$,'2020-09-29T09:00:00Z',$${\"geometry\":{\"type\":\"GeoProperty\",\"value\":{\"coordinates\":[3.63969,43.43358],\"type\":\"Point\"}},\"type\":\"Feature\"}$$,ST_GeomFromGeoJSON('{\"coordinates\":[3.63969,43.43358],\"type\":\"Point\"}'),43.43358,3.63969,null,$$test 01$$,'2020-09-29T09:00:00Z',null,'2019-07-08T04:55:34.983Z',null,'2020-09-29T09:00:00Z',null)";
         List<String> valuesForInsert = backend.getValuesForInsert(
                 attrPersistence,
                 entities.get(0),


### PR DESCRIPTION
In this PR, we add functionality for `geoProperties`.

1. If the geoproperty is a Point, extract latitude and longitude into two separate (numeric) columns
2. For all the geoproperties (including Point):
- export the coordinates into a separate (geometry) column (required by PostGIS for geo operations)
- export the coordinates into a separate (text) column containing a Feature GeoJSON object (better for performance reasons to have it ready and not calculate on the fly)