### PR TITLE
feat: add a properties object in the GeoJSON representation of a location

### DIFF
--- a/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/backends/PostgreSQLBackend.java
+++ b/nifi-ngsi-bundle/nifi-ngsi-processors/src/main/java/org/apache/nifi/processors/ngsi/ngsi/backends/PostgreSQLBackend.java
@@ -264,6 +264,11 @@ public class PostgreSQLBackend {
             }
             JSONObject geoJson = new JSONObject();
             geoJson.put("type", "Feature");
+            // to be correctly rendered, viz tools often require a properties object into the geometry object
+            // so add one containing the entity id (only thing common to all entities)
+            JSONObject geoJsonProperties = new JSONObject();
+            geoJsonProperties.put(NGSIConstants.ENTITY_ID, entity.entityId);
+            geometryObject.put("properties", geoJsonProperties);
             geoJson.put("geometry", geometryObject);
 
             String encodedGeometry = encodeAttributeToColumnName(attribute.getAttrName(), "geometry", datasetIdPrefixToTruncate);


### PR DESCRIPTION
To be correctly rendered, viz tools often require a `properties` object into the `geometry` object. So add one containing the entity id (only thing common to all entities).